### PR TITLE
Flag V should be always 0 for OR/ORI operation (provided by yume)

### DIFF
--- a/risc8-alu.v
+++ b/risc8-alu.v
@@ -250,7 +250,6 @@ module risc8_alu(
 			R = Rd | Rr;
 			SV = 0;
 			SN = R7;
-			SV = SN^SC;
 			SS = SN^SV;
 			SZ = R_zero;
 		end


### PR DESCRIPTION
Signed-off-by: Plaque-fcc <Plaque-fcc@github>